### PR TITLE
Minor documentation typos/broken links

### DIFF
--- a/docs/how_to/runtime_type_checking.rst
+++ b/docs/how_to/runtime_type_checking.rst
@@ -45,7 +45,7 @@ are invalid or :class:`InvalidReturnError` when the returned value is invalid.
     ``InvalidReturnError.err``
 
 
-:data:`validate_signature` works on class methods as well, and with many different kinds of arugments.
+:data:`validate_signature` works on class methods as well, and with many different kinds of arguments.
 
 .. testcode:: object
 

--- a/docs/philosophy/async.rst
+++ b/docs/philosophy/async.rst
@@ -60,7 +60,7 @@ While :class:`Validator<koda_validate.Validator>`\s can be defined to work in bo
 :class:`Validator<koda_validate.Validator>` is initialized, Koda Validate will raise an exception if the both of the
 following are true:
 
-1. it is initialized with async-only validation (e.g. defining ``predicates_sync`` or ``validate_object_async`` on applicable :class:`Validator<koda_validate.Validator>`\s)
+1. it is initialized with async-only validation (e.g. defining ``predicates_async`` or ``validate_object_async`` on applicable :class:`Validator<koda_validate.Validator>`\s)
 2. it is invoked synchronously -- i.e. ``some_async_validator(123)`` instead of ``await some_async_validator.validate_async(123)``
 
 

--- a/docs/philosophy/predicates.rst
+++ b/docs/philosophy/predicates.rst
@@ -58,4 +58,4 @@ Here ``int_validator`` has 3 :class:`Predicate<koda_validate.Predicate>`\s, but 
 that failing :class:`Predicate<koda_validate.Predicate>`\s are returned within a :class:`PredicateErrs` instance. We are only able
 to return all the failing :class:`Predicate<koda_validate.Predicate>`\s because we know that each :class:`Predicate` will not be able to change the value.
 
-:class:`Predicate<koda_validate.Predicate>`\s are easy to write -- take a look at [Extension](#extension) for more details.
+:class:`Predicate<koda_validate.Predicate>`\s are easy to write -- take a look at :ref:`how_to/extension:Extension` for more details.


### PR DESCRIPTION
## Issue or goal of PR:
Fix a few minor typos/broken links in docs
## What I did
Fix a few minor typos/broken links in docs
## How to test
build docs and review changed files; Make sure extension link is right

- [ ] unit tests were written / updated

## Documentation
Check one:

- [* ] I updated documentation
OR
- [ ] No documentation updates required
