### PR TITLE
make Invalid.__repr__ human-readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+5.1.0 (Sep 28, 2025)
+- make `Invalid.__repr__` human-readable
+
 5.0.2 (Sep 22, 2025)
 - remove implicit dependency on typing-extensions
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "Koda Validate"
 copyright = "2025, Keith Philpott"
 author = "Keith Philpott"
-release = "5.0.2"
+release = "5.1.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/how_to/dictionaries/is_dict.rst
+++ b/docs/how_to/dictionaries/is_dict.rst
@@ -18,5 +18,10 @@ don't need to initialize it, you can just load :data:`is_dict_validator`.
     Valid(val={'a': 1, 'b': None})
 
     >>> is_dict_validator(None)
-    Invalid(err_type=TypeErr(expected_type=<class 'dict'>), ...)
+    Invalid(
+        err_type=TypeErr(expected_type=<class 'dict'>),
+        value=None,
+        validator=IsDictValidator()
+    )
+
 

--- a/docs/how_to/extension.rst
+++ b/docs/how_to/extension.rst
@@ -44,7 +44,11 @@ Here's how our :class:`Validator` can be used:
     >>> float_validator(5.5)
     Valid(val=5.5)
     >>> float_validator(5)
-    Invalid(err_type=TypeErr(expected_type=<class 'float'>), value=5, ...)
+    Invalid(
+        err_type=TypeErr(expected_type=<class 'float'>),
+        value=5,
+        validator=<SimpleFloatValidator object at ...>
+    )
 
 Predicates
 ----------
@@ -108,7 +112,13 @@ In the code above, if :class:`Predicate<koda_validate.Predicate>` is specified, 
     >>> validator(3.14)
     Valid(val=3.14)
     >>> validator(1.1)
-    Invalid(err_type=PredicateErrs(predicates=[FloatMin(min=2.5)]), value=1.1, ...)
+    Invalid(
+        err_type=PredicateErrs(predicates=[
+            FloatMin(min=2.5),
+        ]),
+        value=1.1,
+        validator=<SimpleFloatValidator object at ...>
+    )
 
 We limited the Validator to one :class:`Predicate` for simplicity. In Koda Validate, :class:`Validator`\s
 that accept predicates typically allow of a ``list`` of :class:`Predicate`\s. Because :class:`Predicate`\s

--- a/docs/how_to/performance.rst
+++ b/docs/how_to/performance.rst
@@ -118,9 +118,17 @@ The validator should behave as the wrapped :class:`Validator` normally would:
     >>> cached_int_validator(5)  # cache hit
     Valid(val=5)
     >>> cached_int_validator("a string")  # cache miss
-    Invalid(err_type=TypeErr(expected_type=<class 'int'>), ...)
+    Invalid(
+        err_type=TypeErr(expected_type=<class 'int'>),
+        value='a string',
+        validator=IntValidator()
+    )
     >>> cached_int_validator("a string")  # cache hit
-    Invalid(err_type=TypeErr(expected_type=<class 'int'>), ...)
+    Invalid(
+        err_type=TypeErr(expected_type=<class 'int'>),
+        value='a string',
+        validator=IntValidator()
+    )
 
 .. note::
 

--- a/docs/how_to/results.rst
+++ b/docs/how_to/results.rst
@@ -25,7 +25,7 @@ generic parameter for the same purpose. So, a ``Validator[int]`` will always ret
 .. note::
 
     ``ValidationResult[int]`` is a more concise way to express ``Union[Valid[int], Invalid]``,
-to which it is exactly equivalent.
+    to which it is exactly equivalent.
 
 Branching on Validity
 ---------------------
@@ -101,10 +101,14 @@ ValidationResult.map()
 Sometimes you might want to convert the data contained by :class:`Valid` into another
 type. ``.map`` allows you to do that without a lot of boilerplate:
 
+.. testsetup:: valid-map
+
+    from koda_validate import IntValidator
+
 .. doctest:: valid-map
-    >>> validator = IntValidator()
-    >>> validator(5).map(str)
-    Valid(val="5")
+
+    >>> IntValidator()(5).map(str)
+    Valid(val='5')
 
 
 Working with ``Invalid``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,11 @@ Easy enough. Let's see how it works:
    Valid(val='a string')
 
    >>> my_first_validator(0)
-   Invalid(err_type=TypeErr(expected_type=<class 'str'>), ...)
+   Invalid(
+       err_type=TypeErr(expected_type=<class 'str'>),
+       value=0,
+       validator=StringValidator()
+   )
 
 For both valid and invalid cases, a value is returned -- no exceptions
 are raised.

--- a/docs/philosophy/predicates.rst
+++ b/docs/philosophy/predicates.rst
@@ -30,10 +30,20 @@ Usage:
     Valid(val=6)
 
     >>> int_validator("a string")
-    Invalid(err_type=TypeErr(expected_type=<class 'int'>), ...)
+    Invalid(
+        err_type=TypeErr(expected_type=<class 'int'>),
+        value='a string',
+        validator=IntValidator(Min(minimum=5, exclusive_minimum=False))
+    )
 
     >>> int_validator(4)
-    Invalid(err_type=PredicateErrs(predicates=[Min(minimum=5, exclusive_minimum=False)]), ...)
+    Invalid(
+        err_type=PredicateErrs(predicates=[
+            Min(minimum=5, exclusive_minimum=False),
+        ]),
+        value=4,
+        validator=IntValidator(Min(minimum=5, exclusive_minimum=False))
+    )
 
 As you can see the value ``4`` passes the ``int`` type check but fails to pass the ``Min(5)`` predicate.
 

--- a/docs/philosophy/validators.rst
+++ b/docs/philosophy/validators.rst
@@ -54,8 +54,11 @@ Usage:
     Valid(val=5)
 
     >>> int_validator("not an integer")
-    Invalid(err_type=TypeErr(expected_type=<class 'int'>), ...)
-
+    Invalid(
+        err_type=TypeErr(expected_type=<class 'int'>),
+        value='not an integer',
+        validator=IntValidator()
+    )
 
 Having this simple function signature-based definition for validation is useful, because it means we can *compose*
 validators. Perhaps the simplest example of this is how ``ListValidator`` accepts a validator for the items of the ``list``:

--- a/koda_validate/bytes.py
+++ b/koda_validate/bytes.py
@@ -13,9 +13,19 @@ class BytesValidator(_ToTupleStandardValidator[bytes]):
     >>> from koda_validate import *
     >>> validator = BytesValidator(not_blank, MaxLength(100), preprocessors=[strip])
     >>> validator(b"")
-    Invalid(err_type=PredicateErrs(predicates=[NotBlank()]), ...)
+    Invalid(
+        err_type=PredicateErrs(predicates=[
+            NotBlank(),
+        ]),
+        value=b'',
+        validator=BytesValidator(NotBlank(), MaxLength(length=100), preprocessors=[Strip()])
+    )
     >>> validator("")
-    Invalid(err_type=TypeErr(expected_type=<class 'bytes'>), ...)
+    Invalid(
+        err_type=TypeErr(expected_type=<class 'bytes'>),
+        value='',
+        validator=BytesValidator(NotBlank(), MaxLength(length=100), preprocessors=[Strip()])
+    )
     >>> validator(b' ok ')
     Valid(val=b'ok')
 

--- a/koda_validate/bytes.py
+++ b/koda_validate/bytes.py
@@ -34,6 +34,6 @@ class BytesValidator(_ToTupleStandardValidator[bytes]):
     :param preprocessors: any number of ``Processor[bytes]``, which will be run before
         :class:`Predicate`\s and :class:`PredicateAsync`\s are checked.
     :param coerce: a function that can control coercion
-    """
+    """  # noqa: E501
 
     _TYPE = bytes

--- a/koda_validate/string.py
+++ b/koda_validate/string.py
@@ -18,9 +18,19 @@ class StringValidator(_ToTupleStandardValidator[str]):
     >>> from koda_validate import *
     >>> validator = StringValidator(not_blank, MaxLength(100), preprocessors=[strip])
     >>> validator("")
-    Invalid(err_type=PredicateErrs(predicates=[NotBlank()]), ...)
+    Invalid(
+        err_type=PredicateErrs(predicates=[
+            NotBlank(),
+        ]),
+        value='',
+        validator=StringValidator(NotBlank(), MaxLength(length=100), preprocessors=[Strip()])
+    )
     >>> validator(None)
-    Invalid(err_type=TypeErr(expected_type=<class 'str'>), ...)
+    Invalid(
+        err_type=TypeErr(expected_type=<class 'str'>),
+        value=None,
+        validator=StringValidator(NotBlank(), MaxLength(length=100), preprocessors=[Strip()])
+    )
     >>> validator(" ok ")
     Valid(val='ok')
 

--- a/koda_validate/string.py
+++ b/koda_validate/string.py
@@ -38,7 +38,7 @@ class StringValidator(_ToTupleStandardValidator[str]):
     :param predicates_async: any number of ``PredicateAsync[str]`` instances
     :param preprocessors: any number of ``Processor[str]``, which will be run before
         :class:`Predicate`\s and :class:`PredicateAsync`\s are checked.
-    """
+    """  # noqa: E501
 
     _TYPE = str
 

--- a/koda_validate/valid.py
+++ b/koda_validate/valid.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from pprint import pformat
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Literal, Union
 
 from koda_validate._generics import A, B
@@ -76,13 +75,7 @@ def _make_invalid_repr(indent: str, inv: Invalid) -> str:
 
 
 def _render_err_type(indent: str, err: "ErrType") -> str:
-    from koda_validate.errors import ErrType, IndexErrs, TypeErr, CoercionErr, KeyErrs
-    # CoercionErr,
-    # ContainerErr,
-    # ExtraKeysErr,
-    # IndexErrs,
-    # KeyErrs,
-    # MapErr,
+    from koda_validate.errors import ErrType, IndexErrs, TypeErr, CoercionErr, KeyErrs, ContainerErr, ExtraKeysErr, MapErr, KeyValErrs
     # MissingKeyErr,
     # # This seems like a type exception worth making..., but that might change in the
     # # future. This is backwards compatible with existing code
@@ -104,7 +97,7 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
         case KeyErrs(keys):
             return f"\n{next_indent_str}".join(
                 ["KeyErrs(keys={", ] + [
-                    f"{key}: {_make_invalid_repr(next_indent_str, k_err)},"
+                    f"{repr(key)}: {_make_invalid_repr(next_indent_str, k_err)},"
                     for key, k_err in keys.items()
                 ]
             ) + f"\n{indent}}})"
@@ -115,8 +108,35 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
                     for key, i_err in i_errs.items()
                 ]
             ) + f"\n{indent}}})"
-        case TypeErr(err):
-            return repr(err)
+        case ContainerErr(child):
+            return f"\n{next_indent_str}".join(
+                [f"ContainerErr(",
+                 f"child={_make_invalid_repr(next_indent_str, child)}",]
+            ) + f"\n{indent})"
+        case ExtraKeysErr(expected_keys):
+            return f"\n{next_indent_str}".join(
+                [f"ExtraKeysErr(",
+                 f"expected_keys={{{", ".join(sorted([repr(k) for k in expected_keys]))}}},""}",]
+            ) + f"\n{indent})"
+        case MapErr(keys):
+            return f"\n{next_indent_str}".join(
+                ["MapErr(keys={", ] + [
+                    f"{repr(key)}: {_render_err_type(next_indent_str, k_err)},"
+                    for key, k_err in keys.items()
+                ]
+            ) + f"\n{indent}}})"
+        case KeyValErrs(key, val):
+            to_join = ["KeyValErrs(",]
+            if key is not None:
+                to_join.append(
+                    f"key={_make_invalid_repr(next_indent_str, key)},"
+                )
+            if val is not None:
+                to_join.append(
+                    f"val={_make_invalid_repr(next_indent_str, val)}"
+                )
+
+            return f"\n{next_indent_str}".join(to_join) + f"\n{indent})"
         case _:
             return repr(err)
 

--- a/koda_validate/valid.py
+++ b/koda_validate/valid.py
@@ -104,7 +104,7 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
         case CoercionErr(compatible_types, dest_type):
             return f"\n{next_indent_str}".join([
                 "CoercionErr(",
-                f"compatible_types={{{", ".join([repr(ct) for ct in compatible_types])}}},",  # noqa: E501
+                f"compatible_types={{{', '.join([repr(ct) for ct in compatible_types])}}},",  # noqa: E501
                 f"dest_type={repr(dest_type)}",
             ]) + f"\n{indent})"
         case KeyErrs(keys):
@@ -129,7 +129,7 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
         case ExtraKeysErr(expected_keys):
             return f"\n{next_indent_str}".join(
                 ["ExtraKeysErr(",
-                 f"expected_keys={{{", ".join(sorted([repr(k) for k in expected_keys]))}}},""}",]  # noqa: E501
+                 f"expected_keys={{{', '.join(sorted([repr(k) for k in expected_keys]))}}},""}",]  # noqa: E501
             ) + f"\n{indent})"
         case MapErr(keys):
             return f"\n{next_indent_str}".join(

--- a/koda_validate/valid.py
+++ b/koda_validate/valid.py
@@ -75,18 +75,17 @@ def _make_invalid_repr(indent: str, inv: Invalid) -> str:
 
 
 def _render_err_type(indent: str, err: "ErrType") -> str:
-    from koda_validate.errors import ErrType, IndexErrs, TypeErr, CoercionErr, KeyErrs, ContainerErr, ExtraKeysErr, MapErr, KeyValErrs
-    # MissingKeyErr,
-    # # This seems like a type exception worth making..., but that might change in the
-    # # future. This is backwards compatible with existing code
-    # PredicateErrs[Any],
-    # SetErrs,
-    # TypeErr,
-    # ValidationErrBase,
-    # UnionErrs,
+    from koda_validate.errors import IndexErrs, CoercionErr, KeyErrs, ContainerErr, ExtraKeysErr, MapErr, KeyValErrs, SetErrs, PredicateErrs, UnionErrs
 
     next_indent_str = indent + (" " * 4)
     match err:
+        case PredicateErrs(predicates):
+            return f"\n{next_indent_str}".join(
+                ["PredicateErrs(predicates=[", ] + [
+                    f"{repr(pred)}"","
+                    for pred in predicates
+                ]
+            ) + f"\n{indent}])"
         case CoercionErr(compatible_types, dest_type):
             return f"\n{next_indent_str}".join(
                 ["CoercionErr(",
@@ -137,6 +136,20 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
                 )
 
             return f"\n{next_indent_str}".join(to_join) + f"\n{indent})"
+        case SetErrs(item_errs):
+            return f"\n{next_indent_str}".join(
+                ["SetErrs(item_errs=[",] + [
+                    f"{_make_invalid_repr(next_indent_str, item)},"
+                    for item in item_errs
+                ]
+            ) + f"\n{indent}])"
+        case UnionErrs(variants):
+            return f"\n{next_indent_str}".join(
+                ["UnionErrs(variants=[",] + [
+                    f"{_make_invalid_repr(next_indent_str, variant)},"
+                    for variant in variants
+                ]
+            ) + f"\n{indent}])"
         case _:
             return repr(err)
 

--- a/koda_validate/valid.py
+++ b/koda_validate/valid.py
@@ -93,67 +93,66 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
                                       UnionErrs)
 
     next_indent_str = indent + (" " * 4)
-    match err:
-        case PredicateErrs(predicates):
-            return f"\n{next_indent_str}".join(
-                ["PredicateErrs(predicates=[", ] + [
-                    f"{repr(pred)}"","
-                    for pred in predicates
-                ]
-            ) + f"\n{indent}])"
-        case CoercionErr(compatible_types, dest_type):
-            return f"\n{next_indent_str}".join([
-                "CoercionErr(",
-                f"compatible_types={{{', '.join([repr(ct) for ct in compatible_types])}}},",  # noqa: E501
-                f"dest_type={repr(dest_type)}",
-            ]) + f"\n{indent})"
-        case KeyErrs(keys):
-            return f"\n{next_indent_str}".join(
-                ["KeyErrs(keys={", ] + [
-                    f"{repr(key)}: {_make_invalid_repr(next_indent_str, k_err)},"
-                    for key, k_err in keys.items()
-                ]
-            ) + f"\n{indent}}})"
-        case IndexErrs(i_errs):
-            return f"\n{next_indent_str}".join(
-                ["IndexErrs(index_errs={",] + [
-                    f"{key}: {_make_invalid_repr(next_indent_str, i_err)},"
-                    for key, i_err in i_errs.items()
-                ]
-            ) + f"\n{indent}}})"
-        case ContainerErr(child):
-            return f"\n{next_indent_str}".join(
-                ["ContainerErr(",
-                 f"child={_make_invalid_repr(next_indent_str, child)}",]
-            ) + f"\n{indent})"
-        case ExtraKeysErr(expected_keys):
-            return f"\n{next_indent_str}".join(
-                ["ExtraKeysErr(",
-                 f"expected_keys={{{', '.join(sorted([repr(k) for k in expected_keys]))}}},""}",]  # noqa: E501
-            ) + f"\n{indent})"
-        case MapErr(keys):
-            return f"\n{next_indent_str}".join(
-                ["MapErr(keys={", ] + [
-                    f"{repr(key)}: {_render_key_val_err(next_indent_str, k_err)},"
-                    for key, k_err in keys.items()
-                ]
-            ) + f"\n{indent}}})"
-        case SetErrs(item_errs):
-            return f"\n{next_indent_str}".join(
-                ["SetErrs(item_errs=[",] + [
-                    f"{_make_invalid_repr(next_indent_str, item)},"
-                    for item in item_errs
-                ]
-            ) + f"\n{indent}])"
-        case UnionErrs(variants):
-            return f"\n{next_indent_str}".join(
-                ["UnionErrs(variants=[",] + [
-                    f"{_make_invalid_repr(next_indent_str, variant)},"
-                    for variant in variants
-                ]
-            ) + f"\n{indent}])"
-        case _:
-            return repr(err)
+    if isinstance(err, PredicateErrs):
+        return f"\n{next_indent_str}".join(
+            ["PredicateErrs(predicates=[", ] + [
+                f"{repr(pred)}"","
+                for pred in err.predicates
+            ]
+        ) + f"\n{indent}])"
+    elif isinstance(err, CoercionErr):
+        return f"\n{next_indent_str}".join([
+            "CoercionErr(",
+            f"compatible_types={{{', '.join([repr(ct) for ct in err.compatible_types])}}},",  # noqa: E501
+            f"dest_type={repr(err.dest_type)}",
+        ]) + f"\n{indent})"
+    elif isinstance(err, KeyErrs):
+        return f"\n{next_indent_str}".join(
+            ["KeyErrs(keys={", ] + [
+                f"{repr(key)}: {_make_invalid_repr(next_indent_str, k_err)},"
+                for key, k_err in err.keys.items()
+            ]
+        ) + f"\n{indent}}})"
+    elif isinstance(err, IndexErrs):
+        return f"\n{next_indent_str}".join(
+            ["IndexErrs(index_errs={",] + [
+                f"{key}: {_make_invalid_repr(next_indent_str, i_err)},"
+                for key, i_err in err.indexes.items()
+            ]
+        ) + f"\n{indent}}})"
+    elif isinstance(err, ContainerErr):
+        return f"\n{next_indent_str}".join(
+            ["ContainerErr(",
+             f"child={_make_invalid_repr(next_indent_str, err.child)}",]
+        ) + f"\n{indent})"
+    elif isinstance(err, ExtraKeysErr):
+        return f"\n{next_indent_str}".join(
+            ["ExtraKeysErr(",
+             f"expected_keys={{{', '.join(sorted([repr(k) for k in err.expected_keys]))}}},""}",]  # noqa: E501
+        ) + f"\n{indent})"
+    elif isinstance(err, MapErr):
+        return f"\n{next_indent_str}".join(
+            ["MapErr(keys={", ] + [
+                f"{repr(key)}: {_render_key_val_err(next_indent_str, k_err)},"
+                for key, k_err in err.keys.items()
+            ]
+        ) + f"\n{indent}}})"
+    elif isinstance(err, SetErrs):
+        return f"\n{next_indent_str}".join(
+            ["SetErrs(item_errs=[",] + [
+                f"{_make_invalid_repr(next_indent_str, item)},"
+                for item in err.item_errs
+            ]
+        ) + f"\n{indent}])"
+    elif isinstance(err, UnionErrs):
+        return f"\n{next_indent_str}".join(
+            ["UnionErrs(variants=[",] + [
+                f"{_make_invalid_repr(next_indent_str, variant)},"
+                for variant in err.variants
+            ]
+        ) + f"\n{indent}])"
+    else:
+        return repr(err)
 
 
 ValidationResult = Union[Valid[A], Invalid]

--- a/koda_validate/valid.py
+++ b/koda_validate/valid.py
@@ -5,6 +5,7 @@ from koda_validate._generics import A, B
 
 if TYPE_CHECKING:
     from koda_validate.base import Validator
+    from koda_validate.errors import ErrType, KeyValErrs
 
 
 @dataclass
@@ -63,6 +64,15 @@ class Invalid:
     def __repr__(self) -> str:
         return _make_invalid_repr("", self)
 
+def _render_key_val_err(indent: str, err: "KeyValErrs") -> str:
+    next_indent_str = indent + (" " * 4)
+    to_join = [
+        "KeyValErrs(",
+        f"key={'None' if err.key is None else _make_invalid_repr(next_indent_str, err.key)},",
+        f"val={'None' if err.val is None else _make_invalid_repr(next_indent_str, err.val)}",
+    ]
+    return f"\n{next_indent_str}".join(to_join) + f"\n{indent})"
+
 
 def _make_invalid_repr(indent: str, inv: Invalid) -> str:
     next_indent = indent + " " * 4
@@ -120,17 +130,10 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
         case MapErr(keys):
             return f"\n{next_indent_str}".join(
                 ["MapErr(keys={", ] + [
-                    f"{repr(key)}: {_render_err_type(next_indent_str, k_err)},"
+                    f"{repr(key)}: {_render_key_val_err(next_indent_str, k_err)},"
                     for key, k_err in keys.items()
                 ]
             ) + f"\n{indent}}})"
-        case KeyValErrs(key, val):
-            to_join = [
-                "KeyValErrs(",
-                f"key={'None' if key is None else _make_invalid_repr(next_indent_str, key)},",
-                f"val={'None' if val is None else _make_invalid_repr(next_indent_str, val)}",
-            ]
-            return f"\n{next_indent_str}".join(to_join) + f"\n{indent})"
         case SetErrs(item_errs):
             return f"\n{next_indent_str}".join(
                 ["SetErrs(item_errs=[",] + [

--- a/koda_validate/valid.py
+++ b/koda_validate/valid.py
@@ -64,12 +64,15 @@ class Invalid:
     def __repr__(self) -> str:
         return _make_invalid_repr("", self)
 
+
 def _render_key_val_err(indent: str, err: "KeyValErrs") -> str:
     next_indent_str = indent + (" " * 4)
+    k = err.key
+    v = err.val
     to_join = [
         "KeyValErrs(",
-        f"key={'None' if err.key is None else _make_invalid_repr(next_indent_str, err.key)},",
-        f"val={'None' if err.val is None else _make_invalid_repr(next_indent_str, err.val)}",
+        f"key={'None' if k is None else _make_invalid_repr(next_indent_str, k)},",
+        f"val={'None' if v is None else _make_invalid_repr(next_indent_str, v)}",
     ]
     return f"\n{next_indent_str}".join(to_join) + f"\n{indent})"
 
@@ -85,7 +88,9 @@ def _make_invalid_repr(indent: str, inv: Invalid) -> str:
 
 
 def _render_err_type(indent: str, err: "ErrType") -> str:
-    from koda_validate.errors import IndexErrs, CoercionErr, KeyErrs, ContainerErr, ExtraKeysErr, MapErr, KeyValErrs, SetErrs, PredicateErrs, UnionErrs
+    from koda_validate.errors import (IndexErrs, CoercionErr, KeyErrs, ContainerErr,
+                                      ExtraKeysErr, MapErr, SetErrs, PredicateErrs,
+                                      UnionErrs)
 
     next_indent_str = indent + (" " * 4)
     match err:
@@ -97,12 +102,11 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
                 ]
             ) + f"\n{indent}])"
         case CoercionErr(compatible_types, dest_type):
-            return f"\n{next_indent_str}".join(
-                ["CoercionErr(",
-                f"compatible_types={{{", ".join([repr(ct) for ct in compatible_types])}}},",
+            return f"\n{next_indent_str}".join([
+                "CoercionErr(",
+                f"compatible_types={{{", ".join([repr(ct) for ct in compatible_types])}}},",  # noqa: E501
                 f"dest_type={repr(dest_type)}",
-                ]
-            ) + f"\n{indent})"
+            ]) + f"\n{indent})"
         case KeyErrs(keys):
             return f"\n{next_indent_str}".join(
                 ["KeyErrs(keys={", ] + [
@@ -119,13 +123,13 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
             ) + f"\n{indent}}})"
         case ContainerErr(child):
             return f"\n{next_indent_str}".join(
-                [f"ContainerErr(",
+                ["ContainerErr(",
                  f"child={_make_invalid_repr(next_indent_str, child)}",]
             ) + f"\n{indent})"
         case ExtraKeysErr(expected_keys):
             return f"\n{next_indent_str}".join(
-                [f"ExtraKeysErr(",
-                 f"expected_keys={{{", ".join(sorted([repr(k) for k in expected_keys]))}}},""}",]
+                ["ExtraKeysErr(",
+                 f"expected_keys={{{", ".join(sorted([repr(k) for k in expected_keys]))}}},""}",]  # noqa: E501
             ) + f"\n{indent})"
         case MapErr(keys):
             return f"\n{next_indent_str}".join(

--- a/koda_validate/valid.py
+++ b/koda_validate/valid.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
+from pprint import pformat
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Literal, Union
 
 from koda_validate._generics import A, B
-from koda_validate.errors import ErrType
 
 if TYPE_CHECKING:
     from koda_validate.base import Validator
@@ -60,6 +60,65 @@ class Invalid:
 
     def map(self, func: Callable[[Any], B]) -> "ValidationResult[B]":
         return self
+
+    def __repr__(self) -> str:
+        return _make_invalid_repr("", self)
+
+
+def _make_invalid_repr(indent: str, inv: Invalid) -> str:
+    next_indent = indent + " " * 4
+    return f"\n{next_indent}".join([
+        "Invalid(",
+        f"err_type={_render_err_type(next_indent, inv.err_type)},",
+        f"value={repr(inv.value)},",
+        f"validator={repr(inv.validator)}",
+    ]) + f"\n{indent})"
+
+
+def _render_err_type(indent: str, err: "ErrType") -> str:
+    from koda_validate.errors import ErrType, IndexErrs, TypeErr, CoercionErr, KeyErrs
+    # CoercionErr,
+    # ContainerErr,
+    # ExtraKeysErr,
+    # IndexErrs,
+    # KeyErrs,
+    # MapErr,
+    # MissingKeyErr,
+    # # This seems like a type exception worth making..., but that might change in the
+    # # future. This is backwards compatible with existing code
+    # PredicateErrs[Any],
+    # SetErrs,
+    # TypeErr,
+    # ValidationErrBase,
+    # UnionErrs,
+
+    next_indent_str = indent + (" " * 4)
+    match err:
+        case CoercionErr(compatible_types, dest_type):
+            return f"\n{next_indent_str}".join(
+                ["CoercionErr(",
+                f"compatible_types={{{", ".join([repr(ct) for ct in compatible_types])}}},",
+                f"dest_type={repr(dest_type)}",
+                ]
+            ) + f"\n{indent})"
+        case KeyErrs(keys):
+            return f"\n{next_indent_str}".join(
+                ["KeyErrs(keys={", ] + [
+                    f"{key}: {_make_invalid_repr(next_indent_str, k_err)},"
+                    for key, k_err in keys.items()
+                ]
+            ) + f"\n{indent}}})"
+        case IndexErrs(i_errs):
+            return f"\n{next_indent_str}".join(
+                ["IndexErrs(index_errs={",] + [
+                    f"{key}: {_make_invalid_repr(next_indent_str, i_err)},"
+                    for key, i_err in i_errs.items()
+                ]
+            ) + f"\n{indent}}})"
+        case TypeErr(err):
+            return repr(err)
+        case _:
+            return repr(err)
 
 
 ValidationResult = Union[Valid[A], Invalid]

--- a/koda_validate/valid.py
+++ b/koda_validate/valid.py
@@ -125,16 +125,11 @@ def _render_err_type(indent: str, err: "ErrType") -> str:
                 ]
             ) + f"\n{indent}}})"
         case KeyValErrs(key, val):
-            to_join = ["KeyValErrs(",]
-            if key is not None:
-                to_join.append(
-                    f"key={_make_invalid_repr(next_indent_str, key)},"
-                )
-            if val is not None:
-                to_join.append(
-                    f"val={_make_invalid_repr(next_indent_str, val)}"
-                )
-
+            to_join = [
+                "KeyValErrs(",
+                f"key={'None' if key is None else _make_invalid_repr(next_indent_str, key)},",
+                f"val={'None' if val is None else _make_invalid_repr(next_indent_str, val)}",
+            ]
             return f"\n{next_indent_str}".join(to_join) + f"\n{indent})"
         case SetErrs(item_errs):
             return f"\n{next_indent_str}".join(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "koda-validate"
-version = "5.0.2"
+version = "5.1.0"
 readme = "README.md"
 description = "Typesafe, composable validation"
 documentation = "https://koda-validate.readthedocs.io/en/stable/"

--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -3,8 +3,9 @@ from dataclasses import dataclass
 
 from koda import Just
 
-from koda_validate import Invalid, StringValidator, TypeErr, Valid, ListValidator, DataclassValidator, MapValidator, \
-    IntValidator, SetValidator, MaxLength, MinLength, ExactLength
+from koda_validate import (Invalid, StringValidator, TypeErr, Valid, ListValidator,
+                           DataclassValidator, MapValidator, IntValidator, SetValidator,
+                           MaxLength, MinLength, ExactLength)
 from koda_validate.maybe import MaybeValidator
 from koda_validate.typehints import get_typehint_validator
 
@@ -24,6 +25,7 @@ def test_valid_map() -> None:
     assert mapped.value == inv.value
     assert mapped.err_type == inv.err_type
     assert mapped.validator == inv.validator
+
 
 def test_invalid_repr() -> None:
     sv = StringValidator()
@@ -76,7 +78,7 @@ Invalid(
     value={},
     validator=DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>, fail_on_unknown_keys=True)
 )
-""".strip()
+""".strip()  # noqa: 501
 
     mayv = MaybeValidator(ListValidator(StringValidator()))
     assert repr(mayv(Just([4]))) == """
@@ -99,7 +101,6 @@ Invalid(
 )
 """.strip()
 
-
     assert repr(v1({"name": "John", "age": 10, "favorite_color": "blue"})) == """
 Invalid(
     err_type=ExtraKeysErr(
@@ -108,7 +109,7 @@ Invalid(
     value={'name': 'John', 'age': 10, 'favorite_color': 'blue'},
     validator=DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>, fail_on_unknown_keys=True)
 )
-""".strip()
+""".strip()  # noqa: 501
 
     mv = MapValidator(
         key=StringValidator(),
@@ -162,4 +163,4 @@ Invalid(
     value='',
     validator=StringValidator(MaxLength(length=1), MinLength(length=1), ExactLength(length=1))
 )
-""".strip()
+""".strip()  # noqa: 501

--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -21,10 +21,61 @@ def test_valid_map() -> None:
     assert mapped.err_type == inv.err_type
     assert mapped.validator == inv.validator
 
-
 def test_invalid_repr() -> None:
+    sv = StringValidator()
+
+    assert repr(sv(5)) == """
+Invalid(
+    err_type=TypeErr(expected_type=<class 'str'>),
+    value=5,
+    validator=StringValidator()
+)
+""".strip()
+
     lv = get_typehint_validator(list[str])
 
-    print(lv([5]))
-    breakpoint()
-    assert repr(lv([5])) == """Invalid(err_type=IndexErrs(indexes={0: Invalid(err_type=UnionErrs(variants=[Invalid(err_type=TypeErr(expected_type=<class 'str'>), value=5, validator=StringValidator()), Invalid(err_type=CoercionErr(compatible_types={<class 'dict'>, <class 'tests.test_valid.test_invalid_repr.<locals>.Person'>}, dest_type=<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>), value=5, validator=DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>))]), value=5, validator=UnionValidator(StringValidator(), DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>)))}), value=[5], validator=ListValidator(UnionValidator(StringValidator(), DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>))))"""
+    assert repr(lv([4])) == """
+Invalid(
+    err_type=IndexErrs(index_errs={
+        0: Invalid(
+            err_type=TypeErr(expected_type=<class 'str'>),
+            value=4,
+            validator=StringValidator()
+        ),
+    }),
+    value=[4],
+    validator=ListValidator(StringValidator())
+)
+""".strip()
+
+    # @dataclass
+    # class Person:
+    #     name: str
+    #     age: int
+    #
+    # v1 = DataclassValidator(Person, fail_on_unknown_keys=True)
+    #
+    # print(v1({}))
+    #
+    # mayv = MaybeValidator(ListValidator(StringValidator()))
+    # print(mayv(Just([4])))
+    #
+    # print(v1({"name": "John", "age": 10, "favorite_color": "blue"}))
+    #
+    # mv = MapValidator(
+    #     key=StringValidator(),
+    #     value=IntValidator()
+    # )
+    #
+    # print(mv({"ok": "not ok"}))
+    #
+    # setv = SetValidator(IntValidator())
+    #
+    # print(setv({"ok", "not ok"}))
+    #
+    # pred_v = StringValidator(
+    #     MaxLength(1),
+    #     MinLength(1),
+    #     ExactLength(1),
+    # )
+    # print(pred_v(""))

--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -1,6 +1,8 @@
 from copy import copy
+from dataclasses import dataclass
 
-from koda_validate import Invalid, StringValidator, TypeErr, Valid
+from koda_validate import Invalid, StringValidator, TypeErr, Valid, ListValidator
+from koda_validate.typehints import get_typehint_validator
 
 
 def test_valid_map() -> None:
@@ -18,3 +20,11 @@ def test_valid_map() -> None:
     assert mapped.value == inv.value
     assert mapped.err_type == inv.err_type
     assert mapped.validator == inv.validator
+
+
+def test_invalid_repr() -> None:
+    lv = get_typehint_validator(list[str])
+
+    print(lv([5]))
+    breakpoint()
+    assert repr(lv([5])) == """Invalid(err_type=IndexErrs(indexes={0: Invalid(err_type=UnionErrs(variants=[Invalid(err_type=TypeErr(expected_type=<class 'str'>), value=5, validator=StringValidator()), Invalid(err_type=CoercionErr(compatible_types={<class 'dict'>, <class 'tests.test_valid.test_invalid_repr.<locals>.Person'>}, dest_type=<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>), value=5, validator=DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>))]), value=5, validator=UnionValidator(StringValidator(), DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>)))}), value=[5], validator=ListValidator(UnionValidator(StringValidator(), DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>))))"""

--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -1,7 +1,11 @@
 from copy import copy
 from dataclasses import dataclass
 
-from koda_validate import Invalid, StringValidator, TypeErr, Valid, ListValidator
+from koda import Just
+
+from koda_validate import Invalid, StringValidator, TypeErr, Valid, ListValidator, DataclassValidator, MapValidator, \
+    IntValidator, SetValidator, MaxLength, MinLength, ExactLength
+from koda_validate.maybe import MaybeValidator
 from koda_validate.typehints import get_typehint_validator
 
 
@@ -48,34 +52,114 @@ Invalid(
 )
 """.strip()
 
-    # @dataclass
-    # class Person:
-    #     name: str
-    #     age: int
-    #
-    # v1 = DataclassValidator(Person, fail_on_unknown_keys=True)
-    #
-    # print(v1({}))
-    #
-    # mayv = MaybeValidator(ListValidator(StringValidator()))
-    # print(mayv(Just([4])))
-    #
-    # print(v1({"name": "John", "age": 10, "favorite_color": "blue"}))
-    #
-    # mv = MapValidator(
-    #     key=StringValidator(),
-    #     value=IntValidator()
-    # )
-    #
-    # print(mv({"ok": "not ok"}))
-    #
-    # setv = SetValidator(IntValidator())
-    #
-    # print(setv({"ok", "not ok"}))
-    #
-    # pred_v = StringValidator(
-    #     MaxLength(1),
-    #     MinLength(1),
-    #     ExactLength(1),
-    # )
-    # print(pred_v(""))
+    @dataclass
+    class Person:
+        name: str
+        age: int
+
+    v1 = DataclassValidator(Person, fail_on_unknown_keys=True)
+
+    assert repr(v1({})) == """
+Invalid(
+    err_type=KeyErrs(keys={
+        'name': Invalid(
+            err_type=MissingKeyErr(),
+            value={},
+            validator=DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>, fail_on_unknown_keys=True)
+        ),
+        'age': Invalid(
+            err_type=MissingKeyErr(),
+            value={},
+            validator=DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>, fail_on_unknown_keys=True)
+        ),
+    }),
+    value={},
+    validator=DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>, fail_on_unknown_keys=True)
+)
+""".strip()
+
+    mayv = MaybeValidator(ListValidator(StringValidator()))
+    assert repr(mayv(Just([4]))) == """
+Invalid(
+    err_type=ContainerErr(
+        child=Invalid(
+            err_type=IndexErrs(index_errs={
+                0: Invalid(
+                    err_type=TypeErr(expected_type=<class 'str'>),
+                    value=4,
+                    validator=StringValidator()
+                ),
+            }),
+            value=[4],
+            validator=ListValidator(StringValidator())
+        )
+    ),
+    value=Just([4]),
+    validator=MaybeValidator(ListValidator(StringValidator()))
+)
+""".strip()
+
+
+    assert repr(v1({"name": "John", "age": 10, "favorite_color": "blue"})) == """
+Invalid(
+    err_type=ExtraKeysErr(
+        expected_keys={'age', 'name'},}
+    ),
+    value={'name': 'John', 'age': 10, 'favorite_color': 'blue'},
+    validator=DataclassValidator(<class 'tests.test_valid.test_invalid_repr.<locals>.Person'>, fail_on_unknown_keys=True)
+)
+""".strip()
+
+    mv = MapValidator(
+        key=StringValidator(),
+        value=IntValidator()
+    )
+
+    assert repr(mv({"ok": "not ok"})) == """
+Invalid(
+    err_type=MapErr(keys={
+        'ok': KeyValErrs(
+            key=None,
+            val=Invalid(
+                err_type=TypeErr(expected_type=<class 'int'>),
+                value='not ok',
+                validator=IntValidator()
+            )
+        ),
+    }),
+    value={'ok': 'not ok'},
+    validator=MapValidator(key=StringValidator(), value=IntValidator())
+)
+""".strip()
+
+    setv = SetValidator(IntValidator())
+
+    assert repr(setv({"not ok"})) == """
+Invalid(
+    err_type=SetErrs(item_errs=[
+        Invalid(
+            err_type=TypeErr(expected_type=<class 'int'>),
+            value='not ok',
+            validator=IntValidator()
+        ),
+    ]),
+    value={'not ok'},
+    validator=SetValidator(IntValidator())
+)
+""".strip()
+
+    pred_v = StringValidator(
+        MaxLength(1),
+        MinLength(1),
+        ExactLength(1),
+    )
+    assert repr(pred_v("")) == """
+Invalid(
+    err_type=PredicateErrs(predicates=[
+        MinLength(length=1),
+        ExactLength(length=1),
+    ]),
+    value='',
+    validator=StringValidator(MaxLength(length=1), MinLength(length=1), ExactLength(length=1))
+)
+""".strip()


### PR DESCRIPTION
## Issue or goal of PR:
A pretty-print-like output format for Invalid would make use of Invalid in the REPL and elsewhere much easier.

## What I did
- a few functions
- comprehensive-ish tests
- fix docs

## How to test


- [x] unit tests were written / updated

## Documentation
Check one:

- [x] I updated documentation
OR
- [ ] No documentation updates required
